### PR TITLE
(TK-379) Update for jruby-utils namespace reorganization

### DIFF
--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -1,6 +1,6 @@
 puppetlabs.services.request-handler.request-handler-service/request-handler-service
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
-puppetlabs.services.jruby.jruby-pool-manager-service/jruby-pool-manager-service
+puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -12,13 +12,13 @@
             [puppetlabs.services.legacy-routes.legacy-routes-service :refer [legacy-routes-service]]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :refer [authorization-service]]
             [puppetlabs.services.versioned-code-service.versioned-code-service :refer [versioned-code-service]]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tka]
             [clojure.tools.namespace.repl :refer (refresh)]
             [clojure.pprint :as pprint]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [me.raynes.fs :as fs]
             [puppetlabs.kitchensink.core :as ks]))
 

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,6 @@
 (def tk-jetty-version "1.5.9")
 (def ks-version "1.3.1")
 (def ps-version "2.5.0-master-SNAPSHOT")
-(def jruby-utils-version "0.1.0-SNAPSHOT")
 
 (defn deploy-info
   [url]
@@ -57,7 +56,7 @@
                  [net.logstash.logback/logstash-logback-encoder "4.5.1"]
 
 
-                 [puppetlabs/jruby-utils ~jruby-utils-version]
+                 [puppetlabs/jruby-utils "0.1.0"]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-authorization "0.7.0"]
                  [puppetlabs/kitchensink ~ks-version]

--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.puppetserver.cli.gem
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]))
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]))
 
 (defn gem-run!
   [config args]

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetserver.cli.irb
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]))
 
 (defn irb-run!

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.puppetserver.cli.ruby
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]))
 
 (defn ruby-run!

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -14,7 +14,7 @@
   [x]
   (when (map? x)
     (= (:kind x)
-       :puppetlabs.services.jruby.jruby-core/jruby-timeout)))
+       :puppetlabs.services.jruby-pool-manager.jruby-core/jruby-timeout)))
 
 (defn output-error
   [{:keys [uri]} {:keys [msg]} http-status]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -5,12 +5,10 @@
             [puppetlabs.kitchensink.classpath :as ks-classpath]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-puppet-schemas]
-            [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
-            [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
-            [clojure.java.io :as io]
             [clojure.tools.logging :as log])
   (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
            (clojure.lang IFn)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.services.jruby.jruby-puppet-schemas
   (:require [schema.core :as schema]
-            [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]))
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -2,7 +2,7 @@
   (:require [clojure.tools.logging :as log]
             [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.services.jruby.jruby-puppet-core :as core]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby]))

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -8,8 +8,7 @@
             [puppetlabs.ssl-utils.simple :as ssl-simple]
             [puppetlabs.ssl-utils.core :as utils]
             [schema.core :as schema]
-            [puppetlabs.puppetserver.certificate-authority :as ca]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core])
+            [puppetlabs.puppetserver.certificate-authority :as ca])
   (:import (java.io ByteArrayInputStream ByteArrayOutputStream)
            (javax.net.ssl SSLContext)))
 

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -4,7 +4,7 @@
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :refer [puppet-profiler-service]]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
             [me.raynes.fs :as fs]
             [cheshire.core :as cheshire]

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_pool_int_test.clj
@@ -5,7 +5,6 @@
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
@@ -27,12 +26,10 @@
             [clojure.tools.logging :as log]
             [puppetlabs.trapperkeeper.bootstrap :as tk-bootstrap]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :as jruby-utils]
-            [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled]
-            [puppetlabs.trapperkeeper.services.authorization.authorization-service :as tk-auth]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.jruby-agents :as jruby-agents]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core])
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents])
   (:import (org.jruby RubyInstanceConfig$CompileMode)))
 
 (def test-resources-dir
@@ -208,7 +205,8 @@
     (ks-testutils/with-no-jvm-shutdown-hooks
      (let [services [jruby/jruby-puppet-pooled-service profiler/puppet-profiler-service
                      handler-service/request-handler-service ps-config/puppet-server-config-service
-                     jetty9/jetty9-service vcs/versioned-code-service jruby-pool-manager-service]
+                     jetty9/jetty9-service vcs/versioned-code-service
+                     jruby-utils/jruby-pool-manager-service]
            config (-> (jruby-testutils/jruby-puppet-tk-config
                        (jruby-testutils/jruby-puppet-config {:max-active-instances 2
                                                              :borrow-timeout

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -7,7 +7,7 @@
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.services.request-handler.request-handler-service :as handler]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :as jruby-utils]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as webserver]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting]

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -9,9 +9,9 @@
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [cheshire.core :as cheshire]
             [me.raynes.fs :as fs]
-            [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :as jruby-utils]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
             [clojure.tools.logging :as log]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.services.protocols.puppet-server-config :as
@@ -32,9 +32,7 @@
             [puppetlabs.trapperkeeper.services.authorization.authorization-service
              :as authorization]
             [puppetlabs.services.versioned-code-service.versioned-code-service
-             :as vcs]
-            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core])
+             :as vcs])
   (:import (com.puppetlabs.puppetserver JRubyPuppetResponse JRubyPuppet)
            (java.util HashMap)))
 

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -11,11 +11,11 @@
             [puppetlabs.trapperkeeper.testutils.webserver.common :refer [http-get]]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-puppet-testutils]
             [ring.middleware.basic-authentication :as auth]
-            [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
             [schema.core :as schema]
-            [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]))
 
 ;; NOTE: this namespace is pretty disgusting.  It'd be much nicer to test this
 ;; ruby code via ruby spec tests, but since we need to stand up a webserver to
@@ -103,7 +103,7 @@ jruby-config :- jruby-schemas/JRubyConfig
                                                       LocalVariableBehavior/PERSISTENT)
                                  (jruby-internal/init-jruby jruby-config))]
      (doto scripting-container
-       (.setEnvironment (jruby-internal/managed-environment (jruby-internal/get-system-env) (:gem-home jruby-config)))
+       (.setEnvironment (jruby-core/managed-environment (jruby-core/get-system-env) (:gem-home jruby-config)))
        (.setLoadPaths (jruby-puppet-core/managed-load-path jruby-puppet-testutils/ruby-load-path))
        (.runScriptlet "require 'jar-dependencies'")
        (.runScriptlet "require 'puppet/server/http_client'"))

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -5,7 +5,7 @@
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby-puppet]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :as jruby-utils]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -5,7 +5,7 @@
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :refer [puppet-profiler-service]]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
             [schema.core :as schema]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -4,7 +4,7 @@
             [puppetlabs.services.config.puppet-server-config-service :refer :all]
             [puppetlabs.services.config.puppet-server-config-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.app :as tk-app]

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -4,9 +4,8 @@
             [schema.test :as schema-test]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
-            [puppetlabs.trapperkeeper.testutils.logging :as logutils])
-  (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)))
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core])
+  (:import (java.io ByteArrayOutputStream PrintStream)))
 
 (use-fixtures :once schema-test/validate-schemas)
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -1,23 +1,16 @@
 (ns puppetlabs.services.jruby.jruby-puppet-service-test
-  (:import (com.puppetlabs.puppetserver JRubyPuppet))
   (:require [clojure.test :refer :all]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-service :refer :all]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :refer [jruby-pool-manager-service]]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.kitchensink.testutils :as ks-testutils]
             [puppetlabs.trapperkeeper.app :as app]
             [puppetlabs.trapperkeeper.core :as tk]
-            [puppetlabs.trapperkeeper.services :as services]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
-            [clojure.stacktrace :as stacktrace]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as bootstrap]
-            [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
-            [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
-            [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
             [me.raynes.fs :as fs]
             [schema.test :as schema-test]))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -1,16 +1,16 @@
 (ns puppetlabs.services.jruby.jruby-puppet-testutils
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-puppet-schemas]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-service]
             [schema.core :as schema]
-            [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env])
   (:import (clojure.lang IFn)
            (org.jruby.embed LocalContextScope)
            (com.puppetlabs.jruby_utils.jruby ScriptingContainer)
-           (puppetlabs.services.jruby.jruby_schemas JRubyInstance)))
+           (puppetlabs.services.jruby_pool_manager.jruby_schemas JRubyInstance)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -10,9 +10,8 @@
             [ring.mock.request :as ring-mock]
             [puppetlabs.kitchensink.core :as ks]
             [ring.middleware.params :as ring]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]
-            [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core])
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core])
   (:import (java.util HashMap)))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -90,7 +89,7 @@
     (with-redefs [jruby-core/borrow-from-pool-with-timeout (fn [_ _ _] {:jruby-puppet (Object.)})
                   jruby-core/return-to-pool (fn [_ _ _] #())]
       (let [jruby-service (reify jruby/JRubyPuppetService
-                            (get-pool-context [_] (jruby-core/create-pool-context
+                            (get-pool-context [_] (jruby-pool-manager-core/create-pool-context
                                                    (jruby-core/initialize-config {:gem-home "bar"
                                                                                   :ruby-load-path ["foo"]})))
                             (get-environment-class-info [_ _ env]

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -4,7 +4,7 @@
     [puppetlabs.services.master.master-service :refer :all]
     [puppetlabs.services.config.puppet-server-config-service :refer [puppet-server-config-service]]
     [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
-    [puppetlabs.services.jruby.jruby-pool-manager-service :as jruby-utils]
+    [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
     [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
     [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
     [puppetlabs.services.request-handler.request-handler-service :refer [request-handler-service]]

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -14,7 +14,7 @@
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :refer [defservice service]]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby-service]
-            [puppetlabs.services.jruby.jruby-pool-manager-service :as jruby-utils]
+            [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-utils]
             [puppetlabs.puppetserver.bootstrap-testutils :as jruby-bootstrap]
             [puppetlabs.services.protocols.versioned-code :as vc]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
@@ -27,8 +27,8 @@
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization-service]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.testutils :as testutils]
-            [puppetlabs.puppetserver.jruby-request :as jruby-request]
-            [puppetlabs.services.jruby.jruby-core :as jruby-core]))
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Test Data
@@ -331,7 +331,7 @@
 (deftest request-handler-test
     (let [dummy-service (reify jruby-protocol/JRubyPuppetService
                           (get-pool-context [_]
-                            (jruby-core/create-pool-context
+                            (jruby-pool-manager-core/create-pool-context
                              (jruby-core/initialize-config {:gem-home "foo"
                                                             :ruby-load-path ["bar"]}))))]
       (logutils/with-test-logging


### PR DESCRIPTION
And bump to jruby-utils 0.1.0 now that it is released.
